### PR TITLE
Added team looping task

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ Here's how the `config.json` file should be formatted (replace zeros with ID num
   "error_channel": 0,
   "announcement_channel": 0,
   
+  "teams": [
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  
   "db_user": "",
   "db_password": "",
   "db_host": "",

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -84,7 +84,7 @@ class Bot(commands.Bot):
         Returns:
             bool: Whether or not they have the dev role.
         """
-        dev_role = discord.utils.get(user.guild.roles, name="dev")
+        dev_role = discord.utils.get(user.guild.roles, name="Dev")
         return dev_role in user.roles
 
     @staticmethod

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -97,6 +97,10 @@ class Bot(commands.Bot):
         dev_role = discord.utils.get(user.guild.roles, name="Phone Analyst")
         return dev_role in user.roles
 
+    @tasks.loop(seconds=86400)  # repeat once a day
+    async def check_teams_loop(self):
+        pass
+
     @tasks.loop(seconds=5)  # repeat after every 5 seconds
     async def resend_outages_loop(self):
         """Resends all the outages to the #cases channel.
@@ -152,6 +156,7 @@ class Bot(commands.Bot):
 
         await self.add_cog(AnnouncementCommand(self))
 
+        self.check_teams_loop.start()
         self.resend_outages_loop.start()
         self.reset_connection_loop.start()
 

--- a/bot/forms/join_form.py
+++ b/bot/forms/join_form.py
@@ -29,7 +29,7 @@ class JoinForm(ui.Modal, title='Join Form'):
         Args:
             interaction (discord.Interaction): The submit modal interaction
         """
-        user = User(interaction.user.id, str(self.first_name), str(self.last_name), True)
+        user = User(interaction.user.id, str(self.first_name), str(self.last_name), 0, True)
         user.add_to_database(self.bot.connection)
 
         await interaction.response.send_message(content="👍",

--- a/bot/views/claim_view.py
+++ b/bot/views/claim_view.py
@@ -36,7 +36,7 @@ class ClaimView(ui.View):
         case = ActiveClaim.from_id(self.bot.connection, interaction.message.id)
 
         if case is None:
-            await interaction.response.send_message("Error, please try again.", ephemeral=True)
+            await interaction.response.send_message("Error, please try again.", ephemeral=True, delete_after=300)
 
             raise AttributeError(f"Case is none (message ID: {interaction.message.id})")
 
@@ -49,7 +49,7 @@ class ClaimView(ui.View):
                                             timestamp=datetime.now())
             completed_embed.set_author(name=f"{case.case_num}", icon_url=f'{interaction.user.display_avatar}')
             completed_embed.set_footer(text="Completed")
-            await interaction.response.send_message(embed=completed_embed, ephemeral=True)
+            await interaction.response.send_message(embed=completed_embed, ephemeral=True, delete_after=300)
 
             # Send a message in the claims channel and add the lead view to it.
             channel = interaction.user.guild.get_channel(self.bot.claims_channel)  # claims channel

--- a/sql/createdb.sql
+++ b/sql/createdb.sql
@@ -62,6 +62,7 @@ CREATE TABLE `Users`(
     `discord_id` BIGINT UNSIGNED NOT NULL,
     `first_name` VARCHAR(255) NOT NULL,
     `last_name` VARCHAR(255) NOT NULL,
+    `team` BIGINT UNSIGNED NOT NULL,
     `active` TINYINT(1) NOT NULL
 );
 ALTER TABLE

--- a/sql/import_from_csv.py
+++ b/sql/import_from_csv.py
@@ -39,8 +39,8 @@ for file in file_names:
         with connection.cursor() as cursor:
             for row in csv_reader:
                 if file == "users":
-                    sql = "INSERT INTO Users (discord_id, first_name, last_name, active) VALUES (%s, %s, %s, %s)"
-                    cursor.execute(sql, (int(row[0]), row[1], row[2], int(bool(row[3]))))
+                    sql = "INSERT INTO Users (discord_id, first_name, last_name, team, active) VALUES (%s, %s, %s, %s, %s)"
+                    cursor.execute(sql, (int(row[0]), row[1], row[2], int(row[3]), int(bool(row[4]))))
 
                 elif file == "pings":
                     sql = "INSERT INTO Pings (thread_id, message_id, severity, description) VALUES (%s, %s, %s, %s)"


### PR DESCRIPTION
# How to Deploy
1. Add the teams into `config.json` in this format:

```
teams: [
     0,
     0,
     0,
     0,
     0
]
```


2. **Use this SQL statement to update the Users table**
```sql
ALTER TABLE Users ADD COLUMN `team` BIGINT UNSIGNED NOT NULL AFTER `last_name`;
```

3. After updating the Users table in the database, the bot can then be run. On startup, the bot will scan through all users in the Users table and store what team they've been assigned to. After doing this (may take several seconds), refresh the leaderboard to see all team rankings.

## New Users
When a new user joins (runs the /join command), their team is automatically assigned to 0. Every 24 hours, the bot will scan through all users and add their teams to the Users table.