### PR TITLE
Renamed casedist file, fixed #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To setup, first download the latest version of MySQL. Then, create a database an
     ├── status.py # Lists case status enum values
     ├── cogs
         ├── announcement_command.py # /announcement
-        ├── case_dist.py # /casedist
+        ├── casedist_command.py # /casedist
         ├── caseinfo_command.py # /caseinfo
         ├── claim_command.py # /claim
         ├── getlog_command.py # /getlog

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -13,7 +13,7 @@ from bot.cogs.join_command import JoinCommand
 from bot.cogs.announcement_command import AnnouncementCommand
 from bot.cogs.help_command import HelpCommand
 from bot.cogs.leaderboard_command import LeaderboardCommand
-from bot.cogs.case_dist import CaseDistCommand
+from bot.cogs.casedist_command import CaseDistCommand
 from bot.cogs.leadstats_command import LeadStatsCommand
 from bot.cogs.export_command import ExportCommand
 

--- a/bot/cogs/casedist_command.py
+++ b/bot/cogs/casedist_command.py
@@ -27,15 +27,16 @@ class CaseDistCommand(commands.Cog):
 
     @app_commands.command(description="Shows a graph of the timing of case claims")
     @app_commands.default_permissions(mute_members=True)
-    async def casedist(self, interaction: discord.Interaction, previous_days: int) -> None:
+    async def casedist(self, interaction: discord.Interaction, month: int, day: int) -> None:
         """Sends a graph of the case claim time distribution
 
         Args:
             interaction (discord.Interaction): Interaction that the slash command originated from.
-            previous_days (int): The amount of days worth of data that will be used.
+            month (int):
+            day (int):
         """
-        start = datetime.datetime.now() - datetime.timedelta(days=previous_days)
-        start = start.replace(hour=7, minute=0, second=0)
+        current = datetime.datetime.now()
+        start = datetime.datetime(year=current.year, month=month, day=day, hour=7, minute=0, second=0)
 
         days = []  # 44 segments
         for i in range(44):
@@ -59,7 +60,7 @@ class CaseDistCommand(commands.Cog):
         labels = self.create_labels()
 
         # Create plot
-        ax.set_title(f"ITS Case Histogram (Starting {start.strftime('%b %d, %Y')})")
+        ax.set_title(f"Total Case Claim-Time Histogram (Starting {start.strftime('%b %d, %Y')})")
         plt.xticks(rotation=90, ha="right")
 
         ax.bar(labels, days, color="b", zorder=3)
@@ -73,11 +74,9 @@ class CaseDistCommand(commands.Cog):
 
         chart = discord.File(data_stream, filename="chart.png")
 
-        embed = discord.Embed(title="ITS Case Histogram")
+        embed = discord.Embed(title="ITSHD Total Case Claim-Time Histogram")
 
-        embed.set_image(
-            url="attachment://chart.png"
-        )
+        embed.set_image(url="attachment://chart.png")
 
         embed.colour = self.bot.embed_color
 


### PR DESCRIPTION
The **/casedist** command now takes in a month and a day parameter from the user and has a label informing the user that the data is total and is taken at claim-time.

<img width="484" alt="Screenshot 2023-08-08 at 10 41 17 AM" src="https://github.com/ajockelle/CaseClaim/assets/76797236/71d950ec-ae74-4ecd-977a-69094f75e75e">
