### PR TITLE
139 evaldata command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 token.txt
 temp.csv
+techs.csv
+leads.csv
 config.json
 backups/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 token.txt
-temp.csv
-techs.csv
-leads.csv
+*.csv
 config.json
 backups/
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -18,6 +18,7 @@ from bot.cogs.leadstats_command import LeadStatsCommand
 from bot.cogs.ping_command import PingCommand
 from bot.cogs.award_command import AwardCommand
 from bot.cogs.hleaderboard_command import HLeaderboardCommand
+from bot.cogs.evaldata_command import EvaldataCommand
 
 from bot.views.claim_view import ClaimView
 from bot.views.check_view import CheckView
@@ -234,6 +235,7 @@ class Bot(commands.Bot):
 
         await self.add_cog(GetLogCommand(self))
         await self.add_cog(ReportCommand(self))
+        await self.add_cog(EvaldataCommand(self))
 
         await self.add_cog(LeaderboardCommand(self))
         await self.add_cog(HLeaderboardCommand(self))

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -53,22 +53,29 @@ class EvaldataCommand(commands.Cog):
 
         data = self.get_data(month, year)
 
+        if month is not None:
+            tech_filename = f"techs{month}-{year}.csv"
+            lead_filename = f"leads{month}-{year}.csv"
+        else:
+            tech_filename = f"techs{year}.csv"
+            lead_filename = f"leads{year}.csv"
+
         # Create techs csv
-        with open('techs.csv', 'w', newline='', encoding='utf-8') as csvfile:
+        with open(tech_filename, 'w', newline='', encoding='utf-8') as csvfile:
             writer = csv.writer(csvfile)
             for row in data[0]:
                writer.writerow(row)
 
         # Create leads csv
-        with open('leads.csv', 'w', newline='', encoding='utf-8') as csvfile:
+        with open(lead_filename, 'w', newline='', encoding='utf-8') as csvfile:
             writer = csv.writer(csvfile)
             for row in data[1]:
                writer.writerow(row)
 
-        tech_data = discord.File('techs.csv')
-        lead_data = discord.File('leads.csv')
+        tech_data = discord.File(tech_filename)
+        lead_data = discord.File(lead_filename)
 
-        await interaction.followup.send(content=f"Success", files=[tech_data, lead_data])
+        await interaction.followup.send(content=f"", files=[tech_data, lead_data])
 
     def get_data(self, month: Optional[int], year: int) -> tuple[list[Any], list[Any]]:
         """Collects all the data from every tech and every lead

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -49,7 +49,7 @@ class EvaldataCommand(commands.Cog):
             await interaction.response.send_message(content=msg, ephemeral=True, delete_after=180)
             return
 
-        await interaction.response.defer()  # Wait in case process takes a long time
+        await interaction.response.defer(ephemeral=True)  # Wait in case process takes a long time
 
         data = self.get_data(year)
 
@@ -137,10 +137,10 @@ class EvaldataCommand(commands.Cog):
 
             # Add complete/check time differences
             complete_diff = case.complete_time - case.claim_time
-            complete_diff_seconds = complete_diff.seconds + complete_diff.days * 86400
+            complete_diff_seconds = complete_diff.seconds + (complete_diff.days * 86400)
 
             check_diff = case.check_time - case.complete_time
-            check_diff_seconds = check_diff.seconds + check_diff.days * 86400
+            check_diff_seconds = check_diff.seconds + (check_diff.days * 86400)
 
             average_completion_time[case.tech.discord_id] += complete_diff_seconds
             average_check_time[case.lead.discord_id] += check_diff_seconds
@@ -163,18 +163,13 @@ class EvaldataCommand(commands.Cog):
             user_id = techs[key]
             row = [key, total_checked_cases[user_id], total_done_cases[user_id], total_pinged_cases[user_id], total_resolved_cases[user_id], total_kudos_cases[user_id], average_completion_time[user_id], hd_case_percent[user_id]]
             tech_rows.append(row)
-            #tech_rows.append(f"{key},{total_checked_cases[user_id]},{total_done_cases[user_id]},{total_pinged_cases[user_id]},{total_resolved_cases[user_id]},{total_kudos_cases[user_id]},{average_completion_time[user_id]}")
 
         # Create lead rows
         lead_rows = [["Lead", "Total Checked Claims", "Total Done Claims", "Total Pinged Claims", "Total Resolved Claims", "Total Kudos Claims", "Average Claim Check Time (Seconds)", "HD Claim Percent"]]
         for key in dict(sorted(leads.items())):
             user_id = leads[key]
-            row = [key, total_checked_claims[user_id], total_done_claims[user_id], total_pinged_claims[user_id],
-                   total_resolved_claims[user_id], total_kudos_claims[user_id], average_check_time[user_id],
-                   hd_claim_percent[user_id]]
+            row = [key, total_checked_claims[user_id], total_done_claims[user_id], total_pinged_claims[user_id], total_resolved_claims[user_id], total_kudos_claims[user_id], average_check_time[user_id],  hd_claim_percent[user_id]]
             lead_rows.append(row)
-
-            #lead_rows.append(f"{key},{total_checked_claims[user_id]},{total_done_claims[user_id]},{total_pinged_claims[user_id]},{total_resolved_claims[user_id]},{total_kudos_claims[user_id]},{average_check_time[user_id]}")
 
         return tech_rows, lead_rows
 

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -174,7 +174,7 @@ class EvaldataCommand(commands.Cog):
                    round(total_pinged_cases[user_id] / total, 4),
                    round(total_resolved_cases[user_id] / total, 4),
                    round(total_kudos_cases[user_id] / total, 4),
-                   round(total_resolved_cases[user_id] / (total_checked_cases[user_id] + total_pinged_cases[user_id]), 4),
+                   round(total_resolved_cases[user_id] / (total_resolved_cases[user_id] + total_pinged_cases[user_id]), 4) if total_resolved_cases[user_id] + total_pinged_cases[user_id] > 0 else 0,
                    average_completion_time[user_id],
                    hd_case_percent[user_id]]
             tech_rows.append(row)
@@ -196,7 +196,7 @@ class EvaldataCommand(commands.Cog):
                    round(total_pinged_claims[user_id] / total, 4),
                    round(total_resolved_claims[user_id] / total, 4),
                    round(total_kudos_claims[user_id] / total, 4),
-                   round(total_resolved_claims[user_id] / (total_checked_claims[user_id] + total_pinged_claims[user_id]), 4),
+                   round(total_resolved_claims[user_id] / (total_resolved_claims[user_id] + total_pinged_claims[user_id]), 4) if total_resolved_claims[user_id] + total_pinged_claims[user_id] > 0 else 0,
                    average_check_time[user_id],
                    hd_claim_percent[user_id]]
             lead_rows.append(row)

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -70,7 +70,7 @@ class EvaldataCommand(commands.Cog):
 
         await interaction.followup.send(content=f"Success", files=[tech_data, lead_data])
 
-    async def get_data(self, month: Optional[int], year: int) -> tuple[list[Any], list[Any]]:
+    def get_data(self, month: Optional[int], year: int) -> tuple[list[Any], list[Any]]:
         """Collects all the data from every tech and every lead
         and compiles it into data that can easily be written to a
         spreadsheet.
@@ -163,19 +163,11 @@ class EvaldataCommand(commands.Cog):
         # Create tech rows
         tech_rows = [["Tech", "Total Cases", "Total Checked Cases", "Total Done Cases", "Total Pinged Cases", "Total Resolved Cases", "Total Kudos Cases", "Percent Checked", "Percent Done", "Percent Pinged", "Percent Resolved", "Percent Kudos", "Percent Resolved after Pinged", "Average Case Completion Time (Seconds)", "HD Case Percent"]]
 
-        c = await self.bot.fetch_channel(self.bot.cases_channel)
         for key in dict(sorted(techs.items())):
             user_id = techs[key]
             total = total_checked_cases[user_id] + total_done_cases[user_id] + total_pinged_cases[user_id] + total_resolved_cases[user_id] + total_kudos_cases[user_id]
             if key in list(leads.keys()) and total < 100:
                 continue
-
-            try:
-                u = await c.guild.fetch_member(user_id)
-                if self.bot.check_if_pa(u):
-                    continue
-            except:
-                pass
 
             row = [key,
                    total,

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -166,7 +166,7 @@ class EvaldataCommand(commands.Cog):
         for key in dict(sorted(techs.items())):
             user_id = techs[key]
             total = total_checked_cases[user_id] + total_done_cases[user_id] + total_pinged_cases[user_id] + total_resolved_cases[user_id] + total_kudos_cases[user_id]
-            if key in list(leads.keys()) and total < 100:
+            if (total < 3) or (key in list(leads.keys()) and total < 100):
                 continue
 
             row = [key,
@@ -191,6 +191,9 @@ class EvaldataCommand(commands.Cog):
         for key in dict(sorted(leads.items())):
             user_id = leads[key]
             total = total_checked_claims[user_id] + total_done_claims[user_id] + total_pinged_claims[user_id] + total_resolved_claims[user_id] + total_kudos_claims[user_id]
+            if total < 3:
+                continue
+
             row = [key,
                    total,
                    total_checked_claims[user_id],

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -144,35 +144,61 @@ class EvaldataCommand(commands.Cog):
 
             average_completion_time[case.tech.discord_id] += complete_diff_seconds
             average_check_time[case.lead.discord_id] += check_diff_seconds
-        
+
         # Calculate averages
         for key in list(average_completion_time.keys()):
             average_completion_time[key] /= (total_checked_cases[key] + total_done_cases[key] + total_pinged_cases[key] + total_resolved_cases[key] + total_kudos_cases[key])
         for key in list(average_check_time.keys()):
             average_check_time[key] /= (total_checked_claims[key] + total_done_claims[key] + total_pinged_claims[key] + total_resolved_claims[key] + total_kudos_claims[key])
 
-        pct = 0
-        pct2 = 0
         # Calculate percentages
         for key in list(hd_case_percent):
-            hd_case_percent[key] = round((total_checked_cases[key] + total_done_cases[key] + total_pinged_cases[key] + total_resolved_cases[key] + total_kudos_cases[key]) / total_hd_cases, 4)
-            pct += hd_case_percent[key]
+            hd_case_percent[key] = (total_checked_cases[key] + total_done_cases[key] + total_pinged_cases[key] + total_resolved_cases[key] + total_kudos_cases[key]) / total_hd_cases
         for key in list(hd_claim_percent):
-            hd_claim_percent[key] = round((total_checked_claims[key] + total_done_claims[key] + total_pinged_claims[key] + total_resolved_claims[key] + total_kudos_claims[key]) / total_hd_cases, 4)
-            pct2 += hd_claim_percent[key]
+            hd_claim_percent[key] = (total_checked_claims[key] + total_done_claims[key] + total_pinged_claims[key] + total_resolved_claims[key] + total_kudos_claims[key]) / total_hd_cases
 
         # Create tech rows
-        tech_rows = [["Tech", "Total Cases", "Total Checked Cases", "Total Done Cases", "Total Pinged Cases", "Total Resolved Cases", "Total Kudos Cases", "Average Case Completion Time (Seconds)", "HD Case Percent"]]
+        tech_rows = [["Tech", "Total Cases", "Total Checked Cases", "Total Done Cases", "Total Pinged Cases", "Total Resolved Cases", "Total Kudos Cases", "Percent Checked", "Percent Done", "Percent Pinged", "Percent Resolved", "Percent Kudos", "Percent Resolved after Pinged", "Average Case Completion Time (Seconds)", "HD Case Percent"]]
         for key in dict(sorted(techs.items())):
             user_id = techs[key]
-            row = [key, (total_checked_cases[user_id] + total_done_cases[user_id] + total_pinged_cases[user_id] + total_resolved_cases[user_id] + total_kudos_cases[user_id]),total_checked_cases[user_id], total_done_cases[user_id], total_pinged_cases[user_id], total_resolved_cases[user_id], total_kudos_cases[user_id], average_completion_time[user_id], hd_case_percent[user_id]]
+            total = total_checked_cases[user_id] + total_done_cases[user_id] + total_pinged_cases[user_id] + total_resolved_cases[user_id] + total_kudos_cases[user_id]
+            row = [key,
+                   total,
+                   total_checked_cases[user_id],
+                   total_done_cases[user_id],
+                   total_pinged_cases[user_id],
+                   total_resolved_cases[user_id],
+                   total_kudos_cases[user_id],
+                   round(total_checked_cases[user_id] / total, 4),
+                   round(total_done_cases[user_id] / total, 4),
+                   round(total_pinged_cases[user_id] / total, 4),
+                   round(total_resolved_cases[user_id] / total, 4),
+                   round(total_kudos_cases[user_id] / total, 4),
+                   round(total_resolved_cases[user_id] / (total_checked_cases[user_id] + total_pinged_cases[user_id]), 4),
+                   average_completion_time[user_id],
+                   hd_case_percent[user_id]]
             tech_rows.append(row)
 
         # Create lead rows
-        lead_rows = [["Lead", "Total Cases", "Total Checked Claims", "Total Done Claims", "Total Pinged Claims", "Total Resolved Claims", "Total Kudos Claims", "Average Claim Check Time (Seconds)", "HD Claim Percent"]]
+        lead_rows = [["Lead", "Total Cases", "Total Checked Claims", "Total Done Claims", "Total Pinged Claims", "Total Resolved Claims", "Total Kudos Claims", "Percent Checked", "Percent Done", "Percent Pinged", "Percent Resolved", "Percent Kudos", "Percent Resolved after Pinged", "Average Claim Check Time (Seconds)", "HD Claim Percent"]]
         for key in dict(sorted(leads.items())):
             user_id = leads[key]
-            row = [key, (total_checked_claims[user_id] + total_done_claims[user_id] + total_pinged_claims[user_id] + total_resolved_claims[user_id] + total_kudos_claims[user_id]), total_checked_claims[user_id], total_done_claims[user_id], total_pinged_claims[user_id], total_resolved_claims[user_id], total_kudos_claims[user_id], average_check_time[user_id],  hd_claim_percent[user_id]]
+            total = total_checked_claims[user_id] + total_done_claims[user_id] + total_pinged_claims[user_id] + total_resolved_claims[user_id] + total_kudos_claims[user_id]
+            row = [key,
+                   total,
+                   total_checked_claims[user_id],
+                   total_done_claims[user_id],
+                   total_pinged_claims[user_id],
+                   total_resolved_claims[user_id],
+                   total_kudos_claims[user_id],
+                   round(total_checked_claims[user_id] / total, 4),
+                   round(total_done_claims[user_id] / total, 4),
+                   round(total_pinged_claims[user_id] / total, 4),
+                   round(total_resolved_claims[user_id] / total, 4),
+                   round(total_kudos_claims[user_id] / total, 4),
+                   round(total_resolved_claims[user_id] / (total_checked_claims[user_id] + total_pinged_claims[user_id]), 4),
+                   average_check_time[user_id],
+                   hd_claim_percent[user_id]]
             lead_rows.append(row)
 
         return tech_rows, lead_rows

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -51,7 +51,7 @@ class EvaldataCommand(commands.Cog):
 
         await interaction.response.defer(ephemeral=True)  # Wait in case process takes a long time
 
-        data = self.get_data(year)
+        data = await self.get_data(year)
 
         # Create techs csv
         with open('techs.csv', 'w', newline='', encoding='utf-8') as csvfile:
@@ -70,7 +70,7 @@ class EvaldataCommand(commands.Cog):
 
         await interaction.followup.send(content=f"Success", files=[tech_data, lead_data])
 
-    def get_data(self, year: int) -> tuple[list[Any], list[Any]]:
+    async def get_data(self, year: int) -> tuple[list[Any], list[Any]]:
         """Collects all the data from every tech and every lead
         and compiles it into data that can easily be written to a
         spreadsheet.
@@ -164,6 +164,15 @@ class EvaldataCommand(commands.Cog):
             total = total_checked_cases[user_id] + total_done_cases[user_id] + total_pinged_cases[user_id] + total_resolved_cases[user_id] + total_kudos_cases[user_id]
             if key in list(leads.keys()) and total < 100:
                 continue
+
+            try:
+                c = await self.bot.fetch_channel(self.bot.cases_channel)
+                u = await c.guild.fetch_member(user_id)
+
+                if self.bot.check_if_pa(u):
+                    continue
+            except:
+                pass
 
             row = [key,
                    total,

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -51,7 +51,7 @@ class EvaldataCommand(commands.Cog):
 
         await interaction.response.defer(ephemeral=True)  # Wait in case process takes a long time
 
-        data = await self.get_data(month, year)
+        data = self.get_data(month, year)
 
         # Create techs csv
         with open('techs.csv', 'w', newline='', encoding='utf-8') as csvfile:

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -162,7 +162,7 @@ class EvaldataCommand(commands.Cog):
         for key in dict(sorted(techs.items())):
             user_id = techs[key]
             total = total_checked_cases[user_id] + total_done_cases[user_id] + total_pinged_cases[user_id] + total_resolved_cases[user_id] + total_kudos_cases[user_id]
-            if user_id in leads.items() and total < 100:
+            if key in list(leads.keys()) and total < 100:
                 continue
 
             row = [key,

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -162,6 +162,9 @@ class EvaldataCommand(commands.Cog):
         for key in dict(sorted(techs.items())):
             user_id = techs[key]
             total = total_checked_cases[user_id] + total_done_cases[user_id] + total_pinged_cases[user_id] + total_resolved_cases[user_id] + total_kudos_cases[user_id]
+            if user_id in leads.items() and total < 100:
+                continue
+
             row = [key,
                    total,
                    total_checked_cases[user_id],

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -158,17 +158,17 @@ class EvaldataCommand(commands.Cog):
             hd_claim_percent[key] = (total_checked_claims[key] + total_done_claims[key] + total_pinged_claims[key] + total_resolved_claims[key] + total_kudos_claims[key]) / total_hd_cases
 
         # Create tech rows
-        tech_rows = [["Tech", "Total Checked Cases", "Total Done Cases", "Total Pinged Cases", "Total Resolved Cases", "Total Kudos Cases", "Average Case Completion Time (Seconds)", "HD Case Percent"]]
+        tech_rows = [["Tech", "Total Cases", "Total Checked Cases", "Total Done Cases", "Total Pinged Cases", "Total Resolved Cases", "Total Kudos Cases", "Average Case Completion Time (Seconds)", "HD Case Percent"]]
         for key in dict(sorted(techs.items())):
             user_id = techs[key]
-            row = [key, total_checked_cases[user_id], total_done_cases[user_id], total_pinged_cases[user_id], total_resolved_cases[user_id], total_kudos_cases[user_id], average_completion_time[user_id], hd_case_percent[user_id]]
+            row = [key, (total_checked_cases[user_id] + total_done_cases[user_id] + total_pinged_cases[user_id] + total_resolved_cases[user_id] + total_kudos_cases[user_id]),total_checked_cases[user_id], total_done_cases[user_id], total_pinged_cases[user_id], total_resolved_cases[user_id], total_kudos_cases[user_id], average_completion_time[user_id], hd_case_percent[user_id]]
             tech_rows.append(row)
 
         # Create lead rows
-        lead_rows = [["Lead", "Total Checked Claims", "Total Done Claims", "Total Pinged Claims", "Total Resolved Claims", "Total Kudos Claims", "Average Claim Check Time (Seconds)", "HD Claim Percent"]]
+        lead_rows = [["Lead", "Total Cases", "Total Checked Claims", "Total Done Claims", "Total Pinged Claims", "Total Resolved Claims", "Total Kudos Claims", "Average Claim Check Time (Seconds)", "HD Claim Percent"]]
         for key in dict(sorted(leads.items())):
             user_id = leads[key]
-            row = [key, total_checked_claims[user_id], total_done_claims[user_id], total_pinged_claims[user_id], total_resolved_claims[user_id], total_kudos_claims[user_id], average_check_time[user_id],  hd_claim_percent[user_id]]
+            row = [key, (total_checked_claims[user_id] + total_done_claims[user_id] + total_pinged_claims[user_id] + total_resolved_claims[user_id] + total_kudos_claims[user_id]), total_checked_claims[user_id], total_done_claims[user_id], total_pinged_claims[user_id], total_resolved_claims[user_id], total_kudos_claims[user_id], average_check_time[user_id],  hd_claim_percent[user_id]]
             lead_rows.append(row)
 
         return tech_rows, lead_rows

--- a/bot/cogs/evaldata_command.py
+++ b/bot/cogs/evaldata_command.py
@@ -144,18 +144,22 @@ class EvaldataCommand(commands.Cog):
 
             average_completion_time[case.tech.discord_id] += complete_diff_seconds
             average_check_time[case.lead.discord_id] += check_diff_seconds
-
+        
         # Calculate averages
         for key in list(average_completion_time.keys()):
             average_completion_time[key] /= (total_checked_cases[key] + total_done_cases[key] + total_pinged_cases[key] + total_resolved_cases[key] + total_kudos_cases[key])
         for key in list(average_check_time.keys()):
             average_check_time[key] /= (total_checked_claims[key] + total_done_claims[key] + total_pinged_claims[key] + total_resolved_claims[key] + total_kudos_claims[key])
 
+        pct = 0
+        pct2 = 0
         # Calculate percentages
         for key in list(hd_case_percent):
-            hd_case_percent[key] = (total_checked_cases[key] + total_done_cases[key] + total_pinged_cases[key] + total_resolved_cases[key] + total_kudos_cases[key]) / total_hd_cases
+            hd_case_percent[key] = round((total_checked_cases[key] + total_done_cases[key] + total_pinged_cases[key] + total_resolved_cases[key] + total_kudos_cases[key]) / total_hd_cases, 4)
+            pct += hd_case_percent[key]
         for key in list(hd_claim_percent):
-            hd_claim_percent[key] = (total_checked_claims[key] + total_done_claims[key] + total_pinged_claims[key] + total_resolved_claims[key] + total_kudos_claims[key]) / total_hd_cases
+            hd_claim_percent[key] = round((total_checked_claims[key] + total_done_claims[key] + total_pinged_claims[key] + total_resolved_claims[key] + total_kudos_claims[key]) / total_hd_cases, 4)
+            pct2 += hd_claim_percent[key]
 
         # Create tech rows
         tech_rows = [["Tech", "Total Cases", "Total Checked Cases", "Total Done Cases", "Total Pinged Cases", "Total Resolved Cases", "Total Kudos Cases", "Average Case Completion Time (Seconds)", "HD Case Percent"]]

--- a/bot/cogs/report_command.py
+++ b/bot/cogs/report_command.py
@@ -29,12 +29,13 @@ class ReportCommand(commands.Cog):
     @app_commands.command(description="Generate a report of cases logged.")
     @app_commands.describe(user="The user the report will be generated for.")
     @app_commands.describe(month="The month for the report (e.g. \"march\").")
+    @app_commands.describe(year="The year for the report (e.g. 2023).")
     @app_commands.choices(status=[
         app_commands.Choice(name="Kudos", value="kudos"),
         app_commands.Choice(name="Pinged", value="pinged")
     ])
     @app_commands.default_permissions(mute_members=True)
-    async def report(self, interaction: discord.Interaction, user: discord.Member = None, month: str = None, status: app_commands.Choice[str] = None):
+    async def report(self, interaction: discord.Interaction, user: discord.Member = None, month: str = None, year: int = None, status: app_commands.Choice[str] = None):
         """Creates a report of all cases, optionally within a certain month and optionally
         for one specific user.
 
@@ -72,7 +73,10 @@ class ReportCommand(commands.Cog):
 
         if month is not None:
             month = int(month_string_to_number(month))
-            description += f" in **{month_number_to_name(month)}**"
+            description += f" in **{month_number_to_name(month)}"
+            if year is not None:
+                description += f"/{year}"
+            description += "**"
         if user is not None:
             user = User.from_id(self.bot.connection, user.id)
             description += f" from user **{user.full_name}**"
@@ -81,7 +85,7 @@ class ReportCommand(commands.Cog):
             status = Status.from_str(status.value)
             description += f" with status **{status}**"
 
-        results = CheckedClaim.search(self.bot.connection, user, month, status)
+        results = CheckedClaim.search(self.bot.connection, user, year, month, status)
         row_str = self.data_to_rowstr(results)
 
         with open('temp.csv', 'w', newline='', encoding='utf-8') as csvfile:

--- a/bot/models/checked_claim.py
+++ b/bot/models/checked_claim.py
@@ -114,6 +114,46 @@ class CheckedClaim(DatabaseItem):
             return data
 
     @staticmethod
+    def get_all_from_year(connection: MySQLConnection, year: int) -> list['CheckedClaim']:
+        """Returns a list of CheckedClaim in a year.
+
+        Args:
+            connection (MySQLConnection): The connection to the MySQL database
+            year (int): The year (e.g. 2023)
+
+        Returns:
+            list[CheckedClaim] - A list of checked cases
+        """
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT * FROM CheckedClaims WHERE YEAR(claim_time) = %s", (year,))
+            results = cursor.fetchall()
+
+            data = []
+            users = {}
+            for result in results:
+                if result[1] == '12341234':
+                    continue
+
+                # Find tech
+                if result[2] in users:
+                    tech = users[result[2]]
+                else:
+                    tech = User.from_id(connection, result[2])
+                    users[result[2]] = tech
+
+                # Find lead
+                if result[3] in users:
+                    lead = users[result[3]]
+                else:
+                    lead = User.from_id(connection, result[3])
+                    users[result[3]] = lead
+
+                data.append(CheckedClaim(result[0], result[1], tech, lead, result[4], result[5], result[6],
+                                         Status.from_str(result[7]), result[8]))
+
+            return data
+
+    @staticmethod
     def get_all_with_case_num(connection: MySQLConnection, case_num: str) -> list['CheckedClaim']:
         """Returns a list of CheckedClaim based on a case number.
         

--- a/bot/models/checked_claim.py
+++ b/bot/models/checked_claim.py
@@ -154,6 +154,46 @@ class CheckedClaim(DatabaseItem):
             return data
 
     @staticmethod
+    def get_all_from_month(connection: MySQLConnection, month: int, year: int) -> list['CheckedClaim']:
+        """Returns a list of CheckedClaim in a month.
+
+        Args:
+            connection (MySQLConnection): The connection to the MySQL database
+            month (int): The month (e.g. 10 for October)
+            year (int): The year (e.g. 2023)
+        Returns:
+            list[CheckedClaim] - A list of checked cases
+        """
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT * FROM CheckedClaims WHERE YEAR(claim_time) = %s AND MONTH(claim_time) = %s", (year, month,))
+            results = cursor.fetchall()
+
+            data = []
+            users = {}
+            for result in results:
+                if result[1] == '12341234':
+                    continue
+
+                # Find tech
+                if result[2] in users:
+                    tech = users[result[2]]
+                else:
+                    tech = User.from_id(connection, result[2])
+                    users[result[2]] = tech
+
+                # Find lead
+                if result[3] in users:
+                    lead = users[result[3]]
+                else:
+                    lead = User.from_id(connection, result[3])
+                    users[result[3]] = lead
+
+                data.append(CheckedClaim(result[0], result[1], tech, lead, result[4], result[5], result[6],
+                                         Status.from_str(result[7]), result[8]))
+
+            return data
+
+    @staticmethod
     def get_all_with_case_num(connection: MySQLConnection, case_num: str) -> list['CheckedClaim']:
         """Returns a list of CheckedClaim based on a case number.
         
@@ -217,7 +257,7 @@ class CheckedClaim(DatabaseItem):
             connection.commit()
 
     @staticmethod
-    def search(connection: MySQLConnection, user: Optional[User] = None, month: Optional[int] = None, status: Status = None) -> list['CheckedClaim']:
+    def search(connection: MySQLConnection, user: Optional[User] = None, year: Optional[int] = None, month: Optional[int] = None, status: Status = None) -> list['CheckedClaim']:
         """Searches the list of CheckedClaims based on the specified parameters.
         
         Args:
@@ -235,8 +275,10 @@ class CheckedClaim(DatabaseItem):
             sql += f" AND tech_id = {user.discord_id}"
 
         if month is not None:
-            now = datetime.now()
-            beginning = f"'{now.year}-{month}-1 00:00:00'"
+            if year is None:
+                year = datetime.now().year
+
+            beginning = f"'{year}-{month}-1 00:00:00'"
 
             match month:
                 case 1 | 3 | 5 | 7 | 8 | 10 | 12:
@@ -245,7 +287,7 @@ class CheckedClaim(DatabaseItem):
                     end = 30
                 case 2:
                     end = 28
-            ending = f"'{now.year}-{month}-{end} 23:59:59'"
+            ending = f"'{year}-{month}-{end} 23:59:59'"
             sql += f" AND claim_time BETWEEN {beginning} AND {ending}"
 
         if status is not None:


### PR DESCRIPTION
Using /evaldata [month] <year> allows leads and PAs to easily access data that can be used to create monthly evals. There are a lot of different statistics measured in the spreadsheets returned by this command, and we can remove some of them based on feedback from other leads.